### PR TITLE
Byte Implementation: Correct usage of size parameter for Rs256Decoder/Encoder

### DIFF
--- a/ErrorCorrection/ByteImpl/ByteImplTester.cs
+++ b/ErrorCorrection/ByteImpl/ByteImplTester.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ErrorCorrection.ByteImpl
 {
@@ -15,14 +12,14 @@ namespace ErrorCorrection.ByteImpl
             DecoderValidTest();
             DecoderErrorTest();
 
-            PerformanceTest_GF16_4();
-            PerformanceTest_GF256_16();
+            PerformanceTest_GF15_4();
+            PerformanceTest_GF255_16();
         }
 
         public static void EncoderTest()
         {
-            Rs256Encoder encoder = new Rs256Encoder( 16, 11, 0x13 );
-            byte[] message = { 0, 0, 0, 0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+            Rs256Encoder encoder = new Rs256Encoder( 15, 11, 0x13 );
+            byte[] message =         { 0,  0, 0, 0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
             byte[] encodedMessage = { 12, 12, 3, 3, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
 
             encoder.Encode( message );
@@ -32,7 +29,7 @@ namespace ErrorCorrection.ByteImpl
 
         public static void DecoderValidTest()
         {
-            Rs256Decoder decoder = new Rs256Decoder( 16, 11, 0x13 );
+            Rs256Decoder decoder = new Rs256Decoder( 15, 11, 0x13 );
             byte[] message = { 12, 12, 3, 3, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
             byte[] cleanMessage = { 12, 12, 3, 3, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
 
@@ -43,7 +40,7 @@ namespace ErrorCorrection.ByteImpl
 
         public static void DecoderErrorTest()
         {
-            Rs256Decoder decoder = new Rs256Decoder( 16, 11, 0x13 );
+            Rs256Decoder decoder = new Rs256Decoder( 15, 11, 0x13 );
             // Note the errors:             v                   v
             byte[] message =      { 12, 12, 1, 3, 11, 10, 9, 8, 1, 6, 5, 4, 3, 2, 1 };
             byte[] cleanMessage = { 12, 12, 3, 3, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
@@ -53,14 +50,14 @@ namespace ErrorCorrection.ByteImpl
             ArrayHelpers.CheckArrayEquals( message, cleanMessage );
         }
 
-        public static void PerformanceTest_GF16_4()
+        public static void PerformanceTest_GF15_4()
         {
-            PerformanceTest( "RS256_16/4", 16, 11, 0x13 );
+            PerformanceTest( "RS256_15/4", 15, 11, 0x13 );
         }
 
-        public static void PerformanceTest_GF256_16()
+        public static void PerformanceTest_GF255_16()
         {
-            PerformanceTest( "RS256_256/16", 256, 255 - 16, 0x011d );
+            PerformanceTest( "RS256_255/16", 255, 255 - 16, 0x011d );
         }
 
         private static void PerformanceTest( string name, int size, int dataBytes, int poly )

--- a/ErrorCorrection/ByteImpl/Rs256Decoder.cs
+++ b/ErrorCorrection/ByteImpl/Rs256Decoder.cs
@@ -38,11 +38,11 @@ namespace ErrorCorrection
             this.size = size;
             this.numDataSymbols = numDataSymbols;
             this.fieldGenPoly = fieldGenPoly;
-            this.numCheckBytes = (size - 1) - numDataSymbols;
+            this.numCheckBytes = size - numDataSymbols;
 
-            this.CodeWordSize = size - 1;
+            this.CodeWordSize = size;
 
-            this.gf = new GaloisField256( size, fieldGenPoly );
+            this.gf = new GaloisField256( 256, fieldGenPoly );
 
             // Syndrom calculation buffers
             this.syndroms = new byte[numCheckBytes];
@@ -59,10 +59,10 @@ namespace ErrorCorrection
             this.omega = new byte[numCheckBytes - 2];
             
             // Error position calculation
-            this.errorIndexes = new byte[size - 1];
+            this.errorIndexes = new byte[size];
 
             // Cache of the lookup used in the ChienSearch process.
-            this.chienCache = new byte[size - 1];
+            this.chienCache = new byte[size];
 
             for( int i = 0; i < this.chienCache.Length; i++ )
             {

--- a/ErrorCorrection/ByteImpl/Rs256Encoder.cs
+++ b/ErrorCorrection/ByteImpl/Rs256Encoder.cs
@@ -35,16 +35,16 @@ namespace ErrorCorrection
         {
             this.size = size;
             this.decodedSize = decodedSize;
-            this.checkwords = (size - 1) - decodedSize;
+            this.checkwords = size - decodedSize;
 
-            this.gf = new GaloisField256( size, fieldGeneratorPoly );
+            this.gf = new GaloisField256(256, fieldGeneratorPoly );
             this.codeGenPoly = BuildCodeGenPoly();
             this.modTempResult = new byte[this.checkwords];
         }
 
         public int CheckWords { get { return this.checkwords; } }
 
-        public int EncodedSize { get { return this.size - 1; } }
+        public int EncodedSize { get { return this.size; } }
 
         public int DecodedSize { get { return this.decodedSize; } }
 
@@ -97,7 +97,7 @@ namespace ErrorCorrection
 
         private byte[] BuildCodeGenPoly()
         {
-            int numElements = size - decodedSize - 1;
+            int numElements = size - decodedSize;
 
             List<byte[]> polys = new List<byte[]>( (int)numElements );
 


### PR DESCRIPTION
and especially he fact is was used instead of 256 for the size of the GaloisField